### PR TITLE
Update Coiot_UnitLimits_Functions.lua

### DIFF
--- a/Gameplay/Unit Limits (Coiot Edit)/Coiot_UnitLimits_Functions.lua
+++ b/Gameplay/Unit Limits (Coiot Edit)/Coiot_UnitLimits_Functions.lua
@@ -1,5 +1,9 @@
 print("Unit Limits Loading Start")
 
+-- ======= --
+-- DEFINES --
+-- ======= --
+
 local function PopulateUnitTypeTable(query, targetTable)
 	for row in DB.Query(query) do
 		targetTable[row.ID] = row.Type
@@ -13,6 +17,18 @@ PopulateUnitTypeTable("SELECT * FROM Units WHERE Domain = 'DOMAIN_LAND'", landUn
 PopulateUnitTypeTable("SELECT * FROM Units WHERE Domain = 'DOMAIN_AIR'", airUnits)
 PopulateUnitTypeTable("SELECT * FROM Units WHERE Domain = 'DOMAIN_SEA'", seaUnits)
 PopulateUnitTypeTable("SELECT * FROM Units WHERE Domain = 'DOMAIN_HOVER'", hoverUnits)
+
+local tCarriers, tSubmarines, tNukes = {}
+PopulateUnitTypeTable("SELECT * FROM Units WHERE Class = 'UNITCLASS_CARRIER' UNION SELECT * FROM Units WHERE Class = 'UNITCLASS_FW_SUPERCARRIER'", tCarriers)
+PopulateUnitTypeTable("SELECT * FROM Units WHERE Class = 'UNITCLASS_SUBMARINE' UNION SELECT * FROM Units WHERE Class = 'UNITCLASS_NUCLEAR_SUBMARINE' UNION SELECT * FROM Units WHERE Class = 'UNITCLASS_FW_CYBERSUB'", tSubmarines)
+PopulateUnitTypeTable("SELECT * FROM Units WHERE NukeDamageLevel > 0", tNukes)
+
+local iMaxCivs = GameDefines.MAX_MAJOR_CIVS - 1
+local domainLand, domainAir, domainSea, domainHover = GameInfoTypes["DOMAIN_LAND"], GameInfoTypes["DOMAIN_AIR"], GameInfoTypes["DOMAIN_SEA"], GameInfoTypes["DOMAIN_HOVER"]
+
+-- ========= --
+-- FUNCTIONS --
+-- ========= --
 
 local function GetOwnedPlotCount(player)
 	local plotCount = 0
@@ -31,20 +47,30 @@ local function Coiot_UnitLimits_Check(playerID)
 	local carrierCap, submarineCap = 1, 1
 
 	local activeMajorCivs = 0
-	for i = 0, GameDefines.MAX_MAJOR_CIVS - 1 do
+	for i = 0, iMaxCivs do
 		local otherPlayer = Players[i]
-		if otherPlayer:IsAlive() then
+		if otherPlayer and otherPlayer:IsAlive() and (not otherPlayer:IsBarbarian()) and (not otherPlayer:IsMinorCiv()) then
 			activeMajorCivs = activeMajorCivs + 1
 		end
 	end
 
-	-- Adjustment based on game turn
-	local turn = Game.GetGameTurn()
-	if turn >= 400 then landCap = 20 end
-	if turn >= 500 then landCap, airCap, seaCap, hoverCap = 25, 10, 10, 5 end
-	if turn >= 600 then landCap, airCap, seaCap, hoverCap = 30, 15, 15, 10 end
-	if turn >= 700 then landCap, airCap, seaCap, hoverCap = 35, 20, 20, 15 end
-	if activeMajorCivs < 10 then landCap, airCap, seaCap, hoverCap = 50, 25, 25, 20 end
+	-- Adjustment based on game turn and number of living civs
+	if activeMajorCivs < 10 then
+		landCap, airCap, seaCap, hoverCap = 50, 25, 25, 20
+	else
+		local turn = Game.GetGameTurn()
+		if turn >= 400 then
+			if turn >= 700 then
+				landCap, airCap, seaCap, hoverCap = 35, 20, 20, 15
+			elseif turn >= 600 then
+				landCap, airCap, seaCap, hoverCap = 30, 15, 15, 10
+			elseif turn >= 500 then
+				landCap, airCap, seaCap, hoverCap = 25, 10, 10, 5
+			else
+				landCap = 20
+			end
+		end
+	end
 
 	-- City and population-based adjustments
 	local cityCount = player:GetNumCities()
@@ -69,35 +95,35 @@ local function Coiot_UnitLimits_Check(playerID)
 	hoverCap = math.min(hoverCap, plotLimit)
 
 	-- Function to count non-combat units
-	local function CountNonCombatUnits(unitTable)
-		local count = 0
+	local function ConsolidatedCountNonCombatUnits()
+		local landCount, airCount, seaCount, hoverCount, carrierCount, submarineCount, missileCount = 0, 0, 0, 0
 		for unit in player:Units() do
-			if (not unit:IsCombatUnit()) and unitTable[unit:GetUnitType()] then
-				count = count + 1
+			if unit:IsCombatUnit() then
+				local unitDomain = unit:GetDomainType()
+				if unitDomain == domainLand then
+					landCount = landCount + 1
+				elseif unitDomain == domainAir then
+					airCount = airCount + 1
+					if tNukes[unit:GetUnitType()] then
+						missileCount = missileCount + 1
+					end
+				elseif unitDomain == domainSea then
+					seaCount = seaCount + 1
+					local checkedUnitType = unit:GetUnitType()
+					if tSubmarines[checkedUnitType] then
+						submarineCount = submarineCount + 1
+					elseif tCarriers[checkedUnitType] then
+						carrierCount = carrierCount + 1
+					end
+				elseif unitDomain == domainHover then
+					hoverCount = hoverCount + 1
+				end
 			end
 		end
-		return count
+		return landCount, airCount, seaCount, hoverCount, carrierCount, submarineCount, missileCount
 	end
-
-	local landCount = CountNonCombatUnits(landUnits)
-	local airCount = CountNonCombatUnits(airUnits)
-	local seaCount = CountNonCombatUnits(seaUnits)
-	local hoverCount = CountNonCombatUnits(hoverUnits)
-	local carrierCount, submarineCount, missileCount = 0, 0, 0
-
-	for unit in player:Units() do
-		if (not unit:IsCombatUnit()) and seaUnits[unit:GetUnitType()] then
-			seaCount = seaCount + 1
-			if unit:GetUnitClassType() == GameInfoTypes.UNITCLASS_CARRIER or unit:GetUnitClassType() == GameInfoTypes.UNITCLASS_FW_SUPERCARRIER then
-				carrierCount = carrierCount + 1
-			elseif unit:GetUnitClassType() == GameInfoTypes.UNITCLASS_SUBMARINE or unit:GetUnitClassType() == GameInfoTypes.UNITCLASS_NUCLEAR_SUBMARINE or unit:GetUnitClassType() == GameInfoTypes.UNITCLASS_FW_CYBERSUB then
-				submarineCount = submarineCount + 1
-			end
-		end
-		if unit:GetUnitType() == GameInfoTypes.UNIT_NUCLEAR_MISSILE or unit:GetUnitType() == GameInfoTypes.UNIT_ATOMIC_BOMB then
-			missileCount = missileCount + 1
-		end
-	end
+	
+	local landCount, airCount, seaCount, hoverCount, carrierCount, submarineCount, missileCount = ConsolidatedCountNonCombatUnits()
 
 	return landCap, airCap, seaCap, hoverCap, carrierCap, submarineCap, landCount, airCount, seaCount, hoverCount,
 		carrierCount, submarineCount, cityCount, missileCap, missileCount
@@ -111,13 +137,13 @@ local function Coiot_UnitLimits_CanTrain(playerID, cityID, unitType)
 	if landUnits[unitType] and landCount >= landCap then return false end
 	if airUnits[unitType] and airCount >= airCap then return false end
 	if hoverUnits[unitType] and hoverCount >= hoverCap then return false end
-	if unitType == GameInfoTypes["UNIT_NUCLEAR_MISSILE"] or unitType == GameInfoTypes["UNIT_ATOMIC_BOMB"] then
+	if tNukes[unitType] then
 		if missileCount >= missileCap then return false end
 	end
 	if seaUnits[unitType] then
-		if unitType == GameInfoTypes["UNIT_SUBMARINE"] or unitType == GameInfoTypes["UNIT_NUCLEARCARRIER"] or unitType == GameInfoTypes["UNIT_FW_CYBERSUB"] then
+		if tSubmarines[unitType] then
 			if submarineCount >= math.ceil(submarineCap * (cityCount / 2)) then return false end
-		elseif unitType == GameInfoTypes["UNIT_CARRIER"] or unitType == GameInfoTypes["UNIT_FW_SUPERCARRIER"] then
+		elseif tCarriers[unitType] then
 			if carrierCount >= math.ceil(carrierCap * (cityCount / 2)) then return false end
 		elseif seaCount >= seaCap then
 			return false
@@ -125,5 +151,5 @@ local function Coiot_UnitLimits_CanTrain(playerID, cityID, unitType)
 	end
 	return true
 end
-GameEvents.CityCanTrain.Add(Coiot_UnitLimits_CanTrain)
+GameEvents.PlayerCanTrain.Add(Coiot_UnitLimits_CanTrain)
 print("Unit Limits Can Train")


### PR DESCRIPTION
Cleanup pass.
1. Moved variable definitions out of functions for runtime
2. Restructured the updating of caps by turn or living civ count, to reduce the number of times the variables need to be updated
3. Restructured unit counting logic to fit it all in a single iteration of Player:Units()
4. tied the function to PlayerCanTrain rather than CityCanTrain, as that should require fewer checks and I don't think unit limits need to differ by city within one player's empire