### PR TITLE
Update InfoAddictCivRelations.lua

### DIFF
--- a/Gameplay/InfoAddict (EW S4 Edit)/Lua/InfoAddictCivRelations.lua
+++ b/Gameplay/InfoAddict (EW S4 Edit)/Lua/InfoAddictCivRelations.lua
@@ -319,6 +319,7 @@ end;
 
 function BuildView(view)
 	-- logger:debug("Building view: " .. view);
+	--[[
 	local totaltimer = os.clock();
 
 	showVisibleCivIcons();
@@ -335,6 +336,7 @@ function BuildView(view)
 
 	lastView = view;
 	logger:info("Total time to build " .. view .. " view: " .. elapsedTime(totaltimer));
+	--]]
 end;
 
 -- Switch to the political relations view


### PR DESCRIPTION
The function showVisibleCivIcons contains the line that was causing the lua.log error Iris was receiving. My edit comments out the contents of the BuildView function, which is the only place in which showVisibleCivIcons gets called. I believe this change should result in the InfoAddict civ relations screen showing up as blank when visited, without affecting the remainder of InfoAddict's functionality